### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Cache/Storage/Base.php
+++ b/lib/Horde/Cache/Storage/Base.php
@@ -116,6 +116,24 @@ abstract class Horde_Cache_Storage_Base implements Serializable
 
     /**
      */
+    public function __serialize()
+    {
+        return array(
+            $this->_params,
+            $this->_logger,
+        );
+    }
+
+    /**
+     */
+    public function __unserialize($data)
+    {
+        @list($this->_params, $this->_logger) = $data;
+        $this->_initOb();
+    }
+
+    /**
+     */
     public function serialize()
     {
         return serialize(array(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Cache/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Cache/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Cache Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Cache/FileTest.php
+++ b/test/Horde/Cache/FileTest.php
@@ -162,7 +162,7 @@ class Horde_Cache_FileTest extends Horde_Cache_TestBase
         $this->assertFileNotExists($this->dir . '/c/a/horde_cache_testcaf8e34be07426ae7127c1b4829983c1');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         system('rm -r ' . $this->dir);

--- a/test/Horde/Cache/FileTest.php
+++ b/test/Horde/Cache/FileTest.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_FileTest extends Horde_Cache_TestBase
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/FileTest.php
+++ b/test/Horde/Cache/FileTest.php
@@ -138,7 +138,7 @@ class Horde_Cache_FileTest extends Horde_Cache_TestBase
             . $this->dir . "/c/caf8e34be07426ae7127c1b4829983c1\t"
             . ($time - 100) . "\n"
         );
-        $this->assertFileNotExists($this->dir . '/horde_cache_gc');
+        $this->assertFileDoesNotExist($this->dir . '/horde_cache_gc');
     }
 
     public function testGarbageCollection()
@@ -159,8 +159,8 @@ class Horde_Cache_FileTest extends Horde_Cache_TestBase
         $storage->gc();
         $this->assertFileExists($this->dir . '/7/8/horde_cache_test78f825aaa0103319aaa1a30bf4fe3ada');
         $this->assertFileExists($this->dir . '/3/6/horde_cache_test3631578538a2d6ba5879b31a9a42f290');
-        $this->assertFileNotExists($this->dir . '/c/2/horde_cache_testc2add694bf942dc77b376592d9c862cd');
-        $this->assertFileNotExists($this->dir . '/c/a/horde_cache_testcaf8e34be07426ae7127c1b4829983c1');
+        $this->assertFileDoesNotExist($this->dir . '/c/2/horde_cache_testc2add694bf942dc77b376592d9c862cd');
+        $this->assertFileDoesNotExist($this->dir . '/c/a/horde_cache_testcaf8e34be07426ae7127c1b4829983c1');
     }
 
     public function tearDown(): void

--- a/test/Horde/Cache/MongoTest.php
+++ b/test/Horde/Cache/MongoTest.php
@@ -53,7 +53,7 @@ class Horde_Cache_MongoTest extends Horde_Cache_TestBase
         return new Horde_Cache($storage);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         if (!empty($this->mongo)) {

--- a/test/Horde/Cache/Sql/Base.php
+++ b/test/Horde/Cache/Sql/Base.php
@@ -49,7 +49,7 @@ class Horde_Cache_Sql_Base extends Horde_Cache_TestBase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->db->delete('DELETE FROM horde_cache');

--- a/test/Horde/Cache/Sql/Base.php
+++ b/test/Horde/Cache/Sql/Base.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_Sql_Base extends Horde_Cache_TestBase
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/Sql/MysqliTest.php
+++ b/test/Horde/Cache/Sql/MysqliTest.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_Sql_MysqliTest extends Horde_Cache_Sql_Base
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/Sql/Oci8Test.php
+++ b/test/Horde/Cache/Sql/Oci8Test.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_Sql_Oci8Test extends Horde_Cache_Sql_Base
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/Sql/Pdo/MysqlTest.php
+++ b/test/Horde/Cache/Sql/Pdo/MysqlTest.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_Sql_Pdo_MysqlTest extends Horde_Cache_Sql_Base
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/Sql/Pdo/PgsqlTest.php
+++ b/test/Horde/Cache/Sql/Pdo/PgsqlTest.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_Sql_Pdo_PgsqlTest extends Horde_Cache_Sql_Base
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/Sql/Pdo/SqliteTest.php
+++ b/test/Horde/Cache/Sql/Pdo/SqliteTest.php
@@ -19,6 +19,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Cache
  */
+#[\AllowDynamicProperties]
 class Horde_Cache_Sql_Pdo_SqliteTest extends Horde_Cache_Sql_Base
 {
     protected function _getCache($params = array())

--- a/test/Horde/Cache/TestBase.php
+++ b/test/Horde/Cache/TestBase.php
@@ -27,7 +27,7 @@ abstract class Horde_Cache_TestBase extends Horde_Test_Case
 
     abstract protected function _getCache($params = array());
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cache = $this->_getCache();
         if (!$this->cache) {
@@ -109,7 +109,7 @@ abstract class Horde_Cache_TestBase extends Horde_Test_Case
         $this->assertEquals('data1', $this->cache->get('key1', 0));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->cache) {
             $this->cache->clear();

--- a/test/Horde/Cache/XcacheTest.php
+++ b/test/Horde/Cache/XcacheTest.php
@@ -39,7 +39,7 @@ class Horde_Cache_XcacheTest extends Horde_Cache_TestBase
         $this->markTestSkipped('Not supported');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->cache) {
             $this->cache->expire('key1');


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-cache/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian Changes: 1011_php8.1.patch https://salsa.debian.org/horde-team/php-horde-cache/-/blob/debian-sid/debian/patches/1011_php8.1.patch
- Debian changes:  Add 1012_php8.2.patch. Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-cache/-/blob/debian-sid/debian/patches/1012_php8.2.patch
- Debian changes: Silence deprecation warnings for PHPunit 10.x https://salsa.debian.org/horde-team/php-horde-cache/-/blob/debian-sid/debian/patches/1020_phpunit-10.x.patch
