### PR TITLE
refactor(Cache): Storage_Hashtable accepts modern Horde\HashTable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ vendor/
 /phpstan.neon
 # PHPStan cache directory
 /.phpstan.cache/
+
+# Added by horde-components QC --fix-qc-issues
+# Horde installer plugin runtime data
+/var/
+# Horde installer plugin web-accessible directory
+/web/

--- a/lib/Horde/Cache.php
+++ b/lib/Horde/Cache.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 1999-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 1999-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -31,10 +32,10 @@ class Horde_Cache
      *
      * @var array
      */
-    protected $_params = array(
+    protected $_params = [
         'compress' => false,
-        'lifetime' => 86400
-    );
+        'lifetime' => 86400,
+    ];
 
     /**
      * Logger.
@@ -63,9 +64,10 @@ class Horde_Cache
      *   - logger: (Horde_Log_Logger) Log object to use for log/debug messages.
      * </pre>
      */
-    public function __construct(Horde_Cache_Storage_Base $storage,
-                                array $params = array())
-    {
+    public function __construct(
+        Horde_Cache_Storage_Base $storage,
+        array $params = []
+    ) {
         if (isset($params['logger'])) {
             $this->_logger = $params['logger'];
             unset($params['logger']);
@@ -197,7 +199,8 @@ class Horde_Cache
                 $this->_storage->expire($key);
                 return true;
             }
-        } catch (Exception $e) {}
+        } catch (Exception $e) {
+        }
 
         return false;
     }

--- a/lib/Horde/Cache/Exception.php
+++ b/lib/Horde/Cache/Exception.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -20,6 +21,4 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL
  * @package   Cache
  */
-class Horde_Cache_Exception extends Horde_Exception_Wrapped
-{
-}
+class Horde_Cache_Exception extends Horde_Exception_Wrapped {}

--- a/lib/Horde/Cache/Storage/Apc.php
+++ b/lib/Horde/Cache/Storage/Apc.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2006-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2006-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -31,11 +32,11 @@ class Horde_Cache_Storage_Apc extends Horde_Cache_Storage_Base
      *             DEFAULT: ''
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
-        parent::__construct(array_merge(array(
+        parent::__construct(array_merge([
             'prefix' => '',
-        ), $params));
+        ], $params));
     }
 
     /**

--- a/lib/Horde/Cache/Storage/Base.php
+++ b/lib/Horde/Cache/Storage/Base.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -34,14 +35,14 @@ abstract class Horde_Cache_Storage_Base implements Serializable
      *
      * @var array
      */
-    protected $_params = array();
+    protected $_params = [];
 
     /**
      * Constructor.
      *
      * @param array $params  Configuration parameters.
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         $this->_params = array_merge($this->_params, $params);
         $this->_initOb();
@@ -50,9 +51,7 @@ abstract class Horde_Cache_Storage_Base implements Serializable
     /**
      * Do initialization tasks.
      */
-    protected function _initOb()
-    {
-    }
+    protected function _initOb() {}
 
     /**
      * Set the logging object.
@@ -118,16 +117,16 @@ abstract class Horde_Cache_Storage_Base implements Serializable
      */
     public function serialize()
     {
-        return serialize(array(
+        return serialize([
             $this->_params,
-            $this->_logger
-        ));
+            $this->_logger,
+        ]);
     }
     public function __serialize(): array
     {
         return [
             $this->_params,
-            $this->_logger
+            $this->_logger,
         ];
     }
 
@@ -135,12 +134,12 @@ abstract class Horde_Cache_Storage_Base implements Serializable
      */
     public function unserialize($data)
     {
-        @list($this->_params, $this->_logger) = @unserialize($data);
+        @[$this->_params, $this->_logger] = @unserialize($data);
         $this->_initOb();
     }
     public function __unserialize(array $data): void
     {
-        list($this->_params, $this->_logger) = $data;
+        [$this->_params, $this->_logger] = $data;
         $this->_initOb();
     }
 

--- a/lib/Horde/Cache/Storage/Eaccelerator.php
+++ b/lib/Horde/Cache/Storage/Eaccelerator.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2006-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2006-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -33,15 +34,15 @@ class Horde_Cache_Storage_Eaccelerator extends Horde_Cache_Storage_Base
      *
      * @throws Horde_Cache_Exception
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         if (!function_exists('eaccelerator_gc')) {
             throw new Horde_Cache_Exception('eAccelerator must be compiled with support for shared memory to use as caching backend.');
         }
 
-        parent::__construct(array_merge(array(
+        parent::__construct(array_merge([
             'prefix' => '',
-        ), $params));
+        ], $params));
     }
 
     /**

--- a/lib/Horde/Cache/Storage/File.php
+++ b/lib/Horde/Cache/Storage/File.php
@@ -1,6 +1,9 @@
 <?php
+
+use Horde\Util\Util;
+
 /**
- * Copyright 1999-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 1999-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -27,14 +30,14 @@
 class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
 {
     /* Location of the garbage collection data file. */
-    const GC_FILE = 'horde_cache_gc';
+    public const GC_FILE = 'horde_cache_gc';
 
     /**
      * List of key to filename mappings.
      *
      * @var array
      */
-    protected $_file = array();
+    protected $_file = [];
 
     /**
      * Constructor.
@@ -52,12 +55,12 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
      *          DEFAULT: 0
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
-        $params = array_merge(array(
+        $params = array_merge([
             'prefix' => 'cache_',
-            'sub' => 0
-        ), $params);
+            'sub' => 0,
+        ], $params);
 
         if (!isset($params['dir']) || !@is_dir($params['dir'])) {
             $params['dir'] = sys_get_temp_dir();
@@ -74,8 +77,8 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
         $c_time = time();
 
         /* Only do garbage collection 0.1% of the time we create an object. */
-        if (!empty($this->_params['no_gc']) ||
-            (intval(substr($c_time, -3)) !== 0)) {
+        if (!empty($this->_params['no_gc'])
+            || (intval(substr($c_time, -3)) !== 0)) {
             return;
         }
 
@@ -104,9 +107,9 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
     public function set($key, $data, $lifetime = 0)
     {
         $filename = $this->_keyToFile($key, true);
-        $tmp_file = Horde_Util::getTempFile('HordeCache', true, $this->_params['dir']);
+        $tmp_file = Util::getTempFile('HordeCache', true, $this->_params['dir']);
         if (isset($this->_params['umask'])) {
-            chmod($tmp_file, 0666 & ~$this->_params['umask']);
+            chmod($tmp_file, 0o666 & ~$this->_params['umask']);
         }
 
         if (file_put_contents($tmp_file, $data) === false) {
@@ -115,8 +118,8 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
 
         @rename($tmp_file, $filename);
 
-        if ($lifetime &&
-            ($fp = @fopen(dirname($filename) . '/' . self::GC_FILE, 'a'))) {
+        if ($lifetime
+            && ($fp = @fopen(dirname($filename) . '/' . self::GC_FILE, 'a'))) {
             // This may result in duplicate entries in GC_FILE, but we
             // will take care of these whenever we do GC and this is quicker
             // than having to check every time we access the file.
@@ -136,8 +139,8 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
             /* 0 means no expire.
              * Also, If the file was been created after the supplied value,
              * the data is valid (fresh). */
-            if (($lifetime == 0) ||
-                (time() - $lifetime <= filemtime($filename))) {
+            if (($lifetime == 0)
+                || (time() - $lifetime <= filemtime($filename))) {
                 return true;
             }
 
@@ -175,7 +178,7 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
      */
     protected function _getCacheFiles($start = null)
     {
-        $paths = array();
+        $paths = [];
 
         try {
             $it = empty($this->_params['sub'])
@@ -186,9 +189,9 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
         }
 
         foreach ($it as $val) {
-            if (!$val->isDir() &&
-                ($fname = $val->getFilename()) &&
-                (strpos($fname, $this->_params['prefix']) === 0)) {
+            if (!$val->isDir()
+                && ($fname = $val->getFilename())
+                && (strpos($fname, $this->_params['prefix']) === 0)) {
                 $paths[$fname] = $val->getPathname();
             }
         }
@@ -254,8 +257,8 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
     {
         $c_time = time();
 
-        if (!empty($this->_params['sub']) &&
-            file_exists($this->_params['dir'] . '/' . self::GC_FILE)) {
+        if (!empty($this->_params['sub'])
+            && file_exists($this->_params['dir'] . '/' . self::GC_FILE)) {
             // If we cannot migrate, we cannot GC either, because we expect the
             // new format.
             try {
@@ -266,7 +269,7 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
         }
 
         foreach ($this->_getGCFiles() as $filename) {
-            $excepts = array();
+            $excepts = [];
             if (is_readable($filename)) {
                 $fp = fopen($filename, 'r');
                 while (!feof($fp) && ($data = fgets($fp))) {
@@ -276,8 +279,8 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
             }
 
             foreach ($this->_getCacheFiles(dirname($filename)) as $pname) {
-                if (!empty($excepts[$pname]) &&
-                    ($c_time > $excepts[$pname])) {
+                if (!empty($excepts[$pname])
+                    && ($c_time > $excepts[$pname])) {
                     @unlink($pname);
                     unset($excepts[$pname]);
                 }
@@ -303,7 +306,7 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
             return;
         }
 
-        $fhs = array();
+        $fhs = [];
         $fp = fopen($filename, 'r');
         if (!flock($fp, LOCK_EX)) {
             throw new Horde_Cache_Exception('Cannot acquire lock for old garbage collection index');
@@ -312,7 +315,7 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
         // Loops through all cached files from the old index and write their GC
         // information to the new GC indexes.
         while (!feof($fp) && ($data = fgets($fp))) {
-            list($path, $time) = explode("\t", trim($data), 2);
+            [$path, $time] = explode("\t", trim($data), 2);
             $dir = dirname($path);
             if ($dir == $this->_params['dir']) {
                 continue;
@@ -325,7 +328,7 @@ class Horde_Cache_Storage_File extends Horde_Cache_Storage_Base
                     foreach ($fhs as $fh) {
                         fclose($fh);
                     }
-                    $fhs = array();
+                    $fhs = [];
                     $fhs[$dir] = @fopen($dir . '/' . self::GC_FILE, 'a');
                 }
                 if (!$fhs[$dir]) {

--- a/lib/Horde/Cache/Storage/Hashtable.php
+++ b/lib/Horde/Cache/Storage/Hashtable.php
@@ -12,12 +12,23 @@
  * @package  Cache
  */
 
+use Horde\Cache\HashtableStorage;
+use Horde\HashTable\HashTable;
+
 /**
- * Cache storage using the Horde_HashTable interface.
+ * Cache storage using a HashTable transport.
+ *
+ * Accepts either:
+ *   - A modern Horde\HashTable\HashTable (preferred). The class delegates to
+ *     {@see HashtableStorage} for the actual storage operations and supports
+ *     phpredis as well as Predis.
+ *   - A legacy Horde_HashTable_Base instance (deprecated path). Operates on
+ *     the legacy interface for backward compatibility while consumers
+ *     migrate.
  *
  * @author    Michael Slusarz <slusarz@horde.org>
  * @category  Horde
- * @copyright 2013-2017 Horde LLC
+ * @copyright 2013-2026 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Cache
  * @since     2.2.0
@@ -25,16 +36,25 @@
 class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
 {
     /**
-     * HashTable object.
+     * HashTable object (legacy path).
      *
-     * @var Horde_HashTable
+     * @var Horde_HashTable|null
      */
     protected $_hash;
 
     /**
+     * Modern PSR-4 storage delegate, set when a modern HashTable is provided.
+     *
+     * @var HashtableStorage|null
+     */
+    protected ?HashtableStorage $_modern = null;
+
+    /**
      * @param array $params  Additional parameters:
      * <pre>
-     *   - hashtable: (Horde_HashTable) [REQUIRED] A Horde_HashTable object.
+     *   - hashtable: (Horde_HashTable|HashTable) [REQUIRED] HashTable instance.
+     *                Modern Horde\HashTable\HashTable is preferred; legacy
+     *                Horde_HashTable_Base is accepted for BC.
      *   - prefix: (string) The prefix to use for the cache keys.
      *             DEFAULT: ''
      * </pre>
@@ -54,13 +74,27 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     protected function _initOb()
     {
-        $this->_hash = $this->_params['hashtable'];
+        $ht = $this->_params['hashtable'];
+
+        if ($ht instanceof HashTable) {
+            $this->_modern = new HashtableStorage(
+                hashtable: $ht,
+                prefix: (string) $this->_params['prefix'],
+            );
+            return;
+        }
+
+        $this->_hash = $ht;
     }
 
     /**
      */
     public function get($key, $lifetime = 0)
     {
+        if ($this->_modern !== null) {
+            return $this->_modern->getWithLifetime((string) $key, (int) $lifetime);
+        }
+
         $dkey = $this->_getKey($key);
         $query = [$dkey];
         if ($lifetime) {
@@ -81,6 +115,11 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function set($key, $data, $lifetime = 0)
     {
+        if ($this->_modern !== null) {
+            $this->_modern->set((string) $key, $data, (int) $lifetime);
+            return;
+        }
+
         $opts = array_filter([
             'expire' => $lifetime,
         ]);
@@ -93,6 +132,10 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function exists($key, $lifetime = 0)
     {
+        if ($this->_modern !== null) {
+            return $this->_modern->hasWithLifetime((string) $key, (int) $lifetime);
+        }
+
         return ($this->get($key, $lifetime) !== false);
     }
 
@@ -100,6 +143,11 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function expire($key)
     {
+        if ($this->_modern !== null) {
+            $this->_modern->delete((string) $key);
+            return;
+        }
+
         $this->_hash->delete([
             $this->_getKey($key),
             $this->_getKey($key, true),
@@ -110,6 +158,11 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function clear()
     {
+        if ($this->_modern !== null) {
+            $this->_modern->clear();
+            return;
+        }
+
         $this->_hash->clear();
     }
 
@@ -125,5 +178,4 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
     {
         return $this->_params['prefix'] . $key . ($ts ? '_t' : '');
     }
-
 }

--- a/lib/Horde/Cache/Storage/Hashtable.php
+++ b/lib/Horde/Cache/Storage/Hashtable.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2013-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2013-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -38,15 +39,15 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      *             DEFAULT: ''
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         if (!isset($params['hashtable'])) {
             throw new InvalidArgumentException('Missing hashtable parameter.');
         }
 
-        parent::__construct(array_merge(array(
-            'prefix' => ''
-        ), $params));
+        parent::__construct(array_merge([
+            'prefix' => '',
+        ], $params));
     }
 
     /**
@@ -61,15 +62,15 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
     public function get($key, $lifetime = 0)
     {
         $dkey = $this->_getKey($key);
-        $query = array($dkey);
+        $query = [$dkey];
         if ($lifetime) {
             $query[] = $lkey = $this->_getKey($key, true);
         }
 
         $res = $this->_hash->get($query);
 
-        if ($lifetime &&
-            (!$res[$lkey] || (($lifetime + $res[$lkey]) < time()))) {
+        if ($lifetime
+            && (!$res[$lkey] || (($lifetime + $res[$lkey]) < time()))) {
             return false;
         }
 
@@ -80,9 +81,9 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function set($key, $data, $lifetime = 0)
     {
-        $opts = array_filter(array(
-            'expire' => $lifetime
-        ));
+        $opts = array_filter([
+            'expire' => $lifetime,
+        ]);
 
         $this->_hash->set($this->_getKey($key), $data, $opts);
         $this->_hash->set($this->_getKey($key, true), time(), $opts);
@@ -99,10 +100,10 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function expire($key)
     {
-        $this->_hash->delete(array(
+        $this->_hash->delete([
             $this->_getKey($key),
-            $this->_getKey($key, true)
-        ));
+            $this->_getKey($key, true),
+        ]);
     }
 
     /**

--- a/lib/Horde/Cache/Storage/Memcache.php
+++ b/lib/Horde/Cache/Storage/Memcache.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2006-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2006-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -31,7 +32,7 @@ class Horde_Cache_Storage_Memcache extends Horde_Cache_Storage_Base
      *
      * @var array
      */
-    protected $_objectcache = array();
+    protected $_objectcache = [];
 
     /**
      * Memcache object.
@@ -50,7 +51,7 @@ class Horde_Cache_Storage_Memcache extends Horde_Cache_Storage_Base
      *             DEFAULT: ''
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         if (!isset($params['memcache'])) {
             if (isset($params['hashtable'])) {
@@ -60,9 +61,9 @@ class Horde_Cache_Storage_Memcache extends Horde_Cache_Storage_Base
             }
         }
 
-        parent::__construct(array_merge(array(
+        parent::__construct(array_merge([
             'prefix' => '',
-        ), $params));
+        ], $params));
     }
 
     /**
@@ -82,7 +83,7 @@ class Horde_Cache_Storage_Memcache extends Horde_Cache_Storage_Base
             return $this->_objectcache[$key];
         }
 
-        $key_list = array($key);
+        $key_list = [$key];
         if (!empty($lifetime)) {
             $key_list[] = $key . '_e';
         }
@@ -94,9 +95,9 @@ class Horde_Cache_Storage_Memcache extends Horde_Cache_Storage_Base
         }
 
         // If we can't find the expire time, assume we have exceeded it.
-        if (empty($lifetime) ||
-            (($res[$key . '_e'] !== false) &&
-             ($res[$key . '_e'] + $lifetime > time()))) {
+        if (empty($lifetime)
+            || (($res[$key . '_e'] !== false)
+             && ($res[$key . '_e'] + $lifetime > time()))) {
             $this->_objectcache[$key] = $res[$key];
         } else {
             $this->expire($original_key);
@@ -141,7 +142,7 @@ class Horde_Cache_Storage_Memcache extends Horde_Cache_Storage_Base
     public function clear()
     {
         $this->_memcache->flush();
-        $this->_objectcache = array();
+        $this->_objectcache = [];
     }
 
 }

--- a/lib/Horde/Cache/Storage/Memory.php
+++ b/lib/Horde/Cache/Storage/Memory.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -33,15 +34,14 @@ class Horde_Cache_Storage_Memory extends Horde_Cache_Storage_Base
      *
      * @var array
      */
-    private $_cache = array();
+    private $_cache = [];
 
     /**
      */
     public function get($key, $lifetime = 0)
     {
-        return isset($this->_cache[$key])
-            ? $this->_cache[$key]
-            : false;
+        return $this->_cache[$key]
+            ?? false;
     }
 
     /**
@@ -69,7 +69,7 @@ class Horde_Cache_Storage_Memory extends Horde_Cache_Storage_Base
      */
     public function clear()
     {
-        $this->_cache = array();
+        $this->_cache = [];
     }
 
 }

--- a/lib/Horde/Cache/Storage/Memoryoverlay.php
+++ b/lib/Horde/Cache/Storage/Memoryoverlay.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2013-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2013-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -29,7 +30,7 @@ class Horde_Cache_Storage_Memoryoverlay extends Horde_Cache_Storage_Base
      *
      * @var array
      */
-    private $_cache = array();
+    private $_cache = [];
 
     /**
      * Constructor.
@@ -40,7 +41,7 @@ class Horde_Cache_Storage_Memoryoverlay extends Horde_Cache_Storage_Base
      *              backend.
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         if (!isset($params['backend'])) {
             throw new InvalidArgumentException('Missing backend parameter.');
@@ -89,7 +90,7 @@ class Horde_Cache_Storage_Memoryoverlay extends Horde_Cache_Storage_Base
      */
     public function clear()
     {
-        $this->_cache = array();
+        $this->_cache = [];
         $this->_params['backend']->clear();
     }
 

--- a/lib/Horde/Cache/Storage/Mock.php
+++ b/lib/Horde/Cache/Storage/Mock.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -24,6 +25,4 @@
  * @package    Cache
  * @deprecated Use Memory driver instead.
  */
-class Horde_Cache_Storage_Mock extends Horde_Cache_Storage_Memory
-{
-}
+class Horde_Cache_Storage_Mock extends Horde_Cache_Storage_Memory {}

--- a/lib/Horde/Cache/Storage/Mongo.php
+++ b/lib/Horde/Cache/Storage/Mongo.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2013-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2013-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -23,10 +24,10 @@
 class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
 {
     /* Field names. */
-    const CID = 'cid';
-    const DATA = 'data';
-    const EXPIRE = 'expire';
-    const TIMESTAMP = 'ts';
+    public const CID = 'cid';
+    public const DATA = 'data';
+    public const EXPIRE = 'expire';
+    public const TIMESTAMP = 'ts';
 
     /**
      * The MongoDB Collection object for the cache data.
@@ -44,15 +45,15 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
      *   - mongo_db: [REQUIRED] (Horde_Mongo_Client) A MongoDB client object.
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         if (!isset($params['mongo_db'])) {
             throw new InvalidArgumentException('Missing mongo_db parameter.');
         }
 
-        parent::__construct(array_merge(array(
-            'collection' => 'horde_cache'
-        ), $params));
+        parent::__construct(array_merge([
+            'collection' => 'horde_cache',
+        ], $params));
     }
 
     /**
@@ -63,12 +64,12 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
         /* Only do garbage collection 0.1% of the time we create an object. */
         if (substr(time(), -3) === '000') {
             try {
-                $this->_db->remove(array(
-                    self::EXPIRE => array(
+                $this->_db->remove([
+                    self::EXPIRE => [
                         '$exists' => true,
-                        '$lt' => time()
-                    )
-                ));
+                        '$lt' => time(),
+                    ],
+                ]);
             } catch (MongoException $e) {
                 $this->_logger->log($e->getMessage(), 'DEBUG');
             }
@@ -90,17 +91,17 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
         $key = $this->_getCid($key);
 
         /* Build SQL query. */
-        $query = array(
-            self::CID => $key
-        );
+        $query = [
+            self::CID => $key,
+        ];
 
         // 0 lifetime checks for objects which have no expiration
         if ($lifetime != 0) {
-            $query[self::TIMESTAMP] = array('$gte' => time() - $lifetime);
+            $query[self::TIMESTAMP] = ['$gte' => time() - $lifetime];
         }
 
         try {
-            $result = $this->_db->findOne($query, array(self::DATA => true));
+            $result = $this->_db->findOne($query, [self::DATA => true]);
         } catch (MongoException $e) {
             $this->_logger->log($e->getMessage(), 'DEBUG');
             return false;
@@ -129,11 +130,11 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
         $key = $this->_getCid($key);
         $curr = time();
 
-        $data = array(
+        $data = [
             self::CID => $key,
             self::DATA => new MongoBinData($data, MongoBinData::BYTE_ARRAY),
-            self::TIMESTAMP => $curr
-        );
+            self::TIMESTAMP => $curr,
+        ];
 
         // 0 lifetime indicates the object should not be GC'd.
         if (!empty($lifetime)) {
@@ -152,14 +153,14 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
 
         // Remove any old cache data and prevent duplicate keys
         try {
-            $this->_db->update(array(
-                self::CID => $key
-            ), array(
-                '$set' => $data
-            ), array(
+            $this->_db->update([
+                self::CID => $key,
+            ], [
+                '$set' => $data,
+            ], [
                 'upsert' => true,
-                'w' => 0
-            ));
+                'w' => 0,
+            ]);
         } catch (MongoException $e) {
             $this->_logger->log($e->getMessage(), 'DEBUG');
             return false;
@@ -174,13 +175,13 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
         $key = $this->_getCid($key);
 
         /* Build SQL query. */
-        $query = array(
-            self::CID => $key
-        );
+        $query = [
+            self::CID => $key,
+        ];
 
         // 0 lifetime checks for objects which have no expiration
         if ($lifetime != 0) {
-            $query[self::TIMESTAMP] = array('$gte' => time() - $lifetime);
+            $query[self::TIMESTAMP] = ['$gte' => time() - $lifetime];
         }
 
         try {
@@ -212,9 +213,9 @@ class Horde_Cache_Storage_Mongo extends Horde_Cache_Storage_Base
         $key = $this->_getCid($key);
 
         try {
-            $this->_db->remove(array(
-                self::CID => $key
-            ));
+            $this->_db->remove([
+                self::CID => $key,
+            ]);
             if ($this->_logger) {
                 $this->_logger->log(sprintf('Cache expire: %s (cache ID %s)', $okey, $key), 'DEBUG');
             }

--- a/lib/Horde/Cache/Storage/Null.php
+++ b/lib/Horde/Cache/Storage/Null.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2006-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2006-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -31,9 +32,7 @@ class Horde_Cache_Storage_Null extends Horde_Cache_Storage_Base
 
     /**
      */
-    public function set($key, $data, $lifetime = 0)
-    {
-    }
+    public function set($key, $data, $lifetime = 0) {}
 
     /**
      */
@@ -51,8 +50,6 @@ class Horde_Cache_Storage_Null extends Horde_Cache_Storage_Base
 
     /**
      */
-    public function clear()
-    {
-    }
+    public function clear() {}
 
 }

--- a/lib/Horde/Cache/Storage/Session.php
+++ b/lib/Horde/Cache/Storage/Session.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -38,11 +39,11 @@ class Horde_Cache_Storage_Session extends Horde_Cache_Storage_Base
      *              DEFAULT: 'horde_cache_session'
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
-        $params = array_merge(array(
-            'sess_name' => 'horde_cache_session'
-        ), $params);
+        $params = array_merge([
+            'sess_name' => 'horde_cache_session',
+        ], $params);
 
         parent::__construct($params);
     }
@@ -53,7 +54,7 @@ class Horde_Cache_Storage_Session extends Horde_Cache_Storage_Base
     protected function _initOb()
     {
         if (!isset($_SESSION[$this->_params['sess_name']])) {
-            $_SESSION[$this->_params['sess_name']] = array();
+            $_SESSION[$this->_params['sess_name']] = [];
         }
         $this->_sess = &$_SESSION[$this->_params['sess_name']];
     }
@@ -71,10 +72,10 @@ class Horde_Cache_Storage_Session extends Horde_Cache_Storage_Base
      */
     public function set($key, $data, $lifetime = 0)
     {
-        $this->_sess[$key] = array(
+        $this->_sess[$key] = [
             'd' => $data,
-            'l' => $lifetime
-        );
+            'l' => $lifetime,
+        ];
     }
 
     /**
@@ -83,8 +84,8 @@ class Horde_Cache_Storage_Session extends Horde_Cache_Storage_Base
     {
         if (isset($this->_sess[$key])) {
             /* 0 means no expire. */
-            if (($lifetime == 0) ||
-                ((time() - $lifetime) <= $this->_sess[$key]['l'])) {
+            if (($lifetime == 0)
+                || ((time() - $lifetime) <= $this->_sess[$key]['l'])) {
                 return true;
             }
 
@@ -110,7 +111,7 @@ class Horde_Cache_Storage_Session extends Horde_Cache_Storage_Base
      */
     public function clear()
     {
-        $this->_sess = array();
+        $this->_sess = [];
     }
 
 }

--- a/lib/Horde/Cache/Storage/Sql.php
+++ b/lib/Horde/Cache/Storage/Sql.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -56,15 +57,15 @@ class Horde_Cache_Storage_Sql extends Horde_Cache_Storage_Base
      *            DEFAULT: 'horde_cache'
      * </pre>
      */
-    public function __construct($params = array())
+    public function __construct($params = [])
     {
         if (!isset($params['db'])) {
             throw new InvalidArgumentException('Missing db parameter.');
         }
 
-        parent::__construct(array_merge(array(
+        parent::__construct(array_merge([
             'table' => 'horde_cache',
-        ), $params));
+        ], $params));
     }
 
     /**
@@ -84,13 +85,14 @@ class Horde_Cache_Storage_Sql extends Horde_Cache_Storage_Base
             return;
         }
 
-        $query = 'DELETE FROM ' . $this->_params['table'] .
-                 ' WHERE cache_expiration < ? AND cache_expiration <> 0';
-        $values = array(time());
+        $query = 'DELETE FROM ' . $this->_params['table']
+                 . ' WHERE cache_expiration < ? AND cache_expiration <> 0';
+        $values = [time()];
 
         try {
             $this->_db->delete($query, $values);
-        } catch (Horde_Db_Exception $e) {}
+        } catch (Horde_Db_Exception $e) {
+        }
     }
 
     /**
@@ -104,9 +106,9 @@ class Horde_Cache_Storage_Sql extends Horde_Cache_Storage_Base
         $maxage = $timestamp - $lifetime;
 
         /* Build SQL query. */
-        $query = 'SELECT cache_data FROM ' . $this->_params['table'] .
-                 ' WHERE cache_id = ?';
-        $values = array($key);
+        $query = 'SELECT cache_data FROM ' . $this->_params['table']
+                 . ' WHERE cache_id = ?';
+        $values = [$key];
 
         // 0 lifetime checks for objects which have no expiration
         if ($lifetime != 0) {
@@ -156,18 +158,19 @@ class Horde_Cache_Storage_Sql extends Horde_Cache_Storage_Base
 
         // Remove any old cache data and prevent duplicate keys
         $query = 'DELETE FROM ' . $this->_params['table'] . ' WHERE cache_id = ?';
-        $values = array($key);
+        $values = [$key];
         try {
             $this->_db->delete($query, $values);
-        } catch (Horde_Db_Exception $e) {}
+        } catch (Horde_Db_Exception $e) {
+        }
 
         /* Build SQL query. */
-        $values = array(
+        $values = [
             'cache_id' => $key,
             'cache_timestamp' => $timestamp,
             'cache_expiration' => $expiration,
-            'cache_data' => new Horde_Db_Value_Binary($data)
-        );
+            'cache_data' => new Horde_Db_Value_Binary($data),
+        ];
 
         try {
             $this->_db->insertBlob($this->_params['table'], $values);
@@ -184,9 +187,9 @@ class Horde_Cache_Storage_Sql extends Horde_Cache_Storage_Base
         $key = hash('md5', $key);
 
         /* Build SQL query. */
-        $query = 'SELECT 1 FROM ' . $this->_params['table'] .
-                 ' WHERE cache_id = ?';
-        $values = array($key);
+        $query = 'SELECT 1 FROM ' . $this->_params['table']
+                 . ' WHERE cache_id = ?';
+        $values = [$key];
 
         // 0 lifetime checks for objects which have no expiration
         if ($lifetime != 0) {
@@ -221,9 +224,9 @@ class Horde_Cache_Storage_Sql extends Horde_Cache_Storage_Base
     {
         $key = hash('md5', $key);
 
-        $query = 'DELETE FROM ' . $this->_params['table'] .
-                 ' WHERE cache_id = ?';
-        $values = array($key);
+        $query = 'DELETE FROM ' . $this->_params['table']
+                 . ' WHERE cache_id = ?';
+        $values = [$key];
 
         try {
             $this->_db->delete($query, $values);

--- a/lib/Horde/Cache/Storage/Stack.php
+++ b/lib/Horde/Cache/Storage/Stack.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -29,7 +30,7 @@ class Horde_Cache_Storage_Stack extends Horde_Cache_Storage_Base
      *
      * @var string
      */
-    protected $_stack = array();
+    protected $_stack = [];
 
     /**
      * Constructor.
@@ -41,7 +42,7 @@ class Horde_Cache_Storage_Stack extends Horde_Cache_Storage_Base
      *            the 'master' driver, for purposes of writes.
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
         if (!isset($params['stack'])) {
             throw new InvalidArgumentException('Missing stack parameter.');

--- a/lib/Horde/Cache/Storage/Xcache.php
+++ b/lib/Horde/Cache/Storage/Xcache.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2006-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2006-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (LGPL). If you
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
@@ -31,11 +32,11 @@ class Horde_Cache_Storage_Xcache extends Horde_Cache_Storage_Base
      *             DEFAULT: ''
      * </pre>
      */
-    public function __construct(array $params = array())
+    public function __construct(array $params = [])
     {
-        parent::__construct(array_merge(array(
+        parent::__construct(array_merge([
             'prefix' => '',
-        ), $params));
+        ], $params));
     }
 
     /**


### PR DESCRIPTION
`Horde_Cache_Storage_Hashtable` now accepts either:
- a modern `Horde\HashTable\HashTable` instance (preferred); the storage delegates to `Horde\Cache\HashtableStorage` for the actual operations, transparently giving consumers phpredis support
- a legacy `Horde_HashTable_Base` instance (existing BC path)

Detection is by `instanceof` at construction. Existing callers are unaffected.

Refs https://github.com/horde/Core/issues/131