### PR TITLE
fix(cache): delegate legacy Hashtable storage to modern adapter

### DIFF
--- a/lib/Horde/Cache/Storage/Hashtable.php
+++ b/lib/Horde/Cache/Storage/Hashtable.php
@@ -26,9 +26,16 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
     /**
      * HashTable object.
      *
-     * @var Horde_HashTable
+     * @var Horde_HashTable|\Horde\HashTable\HashTable
      */
     protected $_hash;
+
+    /**
+     * Modern storage adapter for Horde\HashTable\HashTable backends.
+     *
+     * @var \Horde\Cache\HashtableStorage|null
+     */
+    protected ?\Horde\Cache\HashtableStorage $_modern = null;
 
     /**
      * @param array $params  Additional parameters:
@@ -54,12 +61,23 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
     protected function _initOb()
     {
         $this->_hash = $this->_params['hashtable'];
+
+        if ($this->_hash instanceof \Horde\HashTable\HashTable) {
+            $this->_modern = new \Horde\Cache\HashtableStorage(
+                hashtable: $this->_hash,
+                prefix: $this->_params['prefix']
+            );
+        }
     }
 
     /**
      */
     public function get($key, $lifetime = 0)
     {
+        if ($this->_modern) {
+            return $this->_modern->getWithLifetime($key, $lifetime);
+        }
+
         $dkey = $this->_getKey($key);
         $query = array($dkey);
         if ($lifetime) {
@@ -80,6 +98,12 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function set($key, $data, $lifetime = 0)
     {
+        if ($this->_modern) {
+            $this->_modern->set($key, $data, $lifetime);
+
+            return;
+        }
+
         $opts = array_filter(array(
             'expire' => $lifetime
         ));
@@ -99,6 +123,12 @@ class Horde_Cache_Storage_Hashtable extends Horde_Cache_Storage_Base
      */
     public function expire($key)
     {
+        if ($this->_modern) {
+            $this->_modern->delete($key);
+
+            return;
+        }
+
         $this->_hash->delete(array(
             $this->_getKey($key),
             $this->_getKey($key, true)


### PR DESCRIPTION
# fix(cache): delegate legacy Hashtable storage to modern adapter

## Summary

- Fix `TypeError` in ActiveSync and other code paths that use the legacy `Horde_Cache` API with a modern `Horde\HashTable\HashTable` backend (e.g. Memcache).
- When `Horde_Core_Factory_Cache` injects a PSR-4 `Horde\HashTable\HashTable` instance, `Horde_Cache_Storage_Hashtable` now delegates to `Horde\Cache\HashtableStorage` instead of calling the old array-based `get()` API.
- Legacy `Horde_HashTable` backends are unchanged and still use the existing code path.

## Problem

After the FRAMEWORK_6_0 HashTable modernization, `Horde\HashTable\Driver\Memcache::get()` accepts only a `string` key. The legacy cache storage adapter still called:

```php
$this->_hash->get($query); // $query is an array
```

That surfaced during ActiveSync requests via:

`Horde_Perms_Sql->exists()` → `Horde_Cache->get()` → `Horde_Cache_Storage_Hashtable->get()` → `Memcache::get(array)`

`Horde_Core_Factory_Cache` already documents routing modern HashTable instances through `HashtableStorage`, but that was never implemented in the storage class.

## Solution

Detect `Horde\HashTable\HashTable` in `_initOb()` and wrap it with `Horde\Cache\HashtableStorage`. Delegate `get()`, `set()`, and `expire()` to that adapter, which correctly uses `getMultiple()` and the modern TTL API.

## Test plan

- [ ] Configure cache driver `Hashtable` with Memcache backend (`$conf['cache']['driver'] = 'Hashtable'`, `$conf['hashtable']['driver'] = 'Memcache'`).
- [ ] Trigger an ActiveSync request (e.g. mobile device sync or `rpc.php` ActiveSync endpoint).
- [ ] Confirm no `TypeError: Memcache::get(): Argument #1 ($key) must be of type string, array given` in Horde logs.
- [ ] Verify cache read/write via legacy adapter:
  ```php
  $storage = new Horde_Cache_Storage_Hashtable(['hashtable' => $hash, 'prefix' => 'horde']);
  $storage->set('test_key', 'test_value', 3600);
  $storage->get('test_key', 3600); // returns 'test_value'
  ```
- [ ] Confirm legacy `Horde_HashTable` backends still work if used directly.
